### PR TITLE
Marked retried tests as ambiguous

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -317,7 +317,8 @@ var generateReport = function (options) {
                     return suite.scenarios.failed++;
                 }
 
-                if (element.ambiguous > 0) {
+                if (element.attemptNumber > 0 || element.ambiguous > 0) {
+                    element.ambiguous++;
                     feature.scenarios.ambiguous++;
                     featuresSummary.isAmbiguous = true;
                     return suite.scenarios.ambiguous++;


### PR DESCRIPTION
As per PR cucumber/cucumber-js#1205 raised at Cucumber-js, we will have retry functionality very soon and it will require support for the same in cucumber html report. Hence, have made the change here.